### PR TITLE
feat: add dependency and security checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Initial `check` command for repo health checks
+- Dependency checks: outdated packages detection
+- Security checks: npm audit integration (high/critical vulns)
+- Package quality checks: test script, engines field
 - CLI with `mro` alias
 - JSON output support (`--json` flag)
 - Basic maintenance checks:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ mro check --json    # JSON output for scripting
 | `.gitignore` | Avoid committing junk |
 | Lockfile conflicts | Multiple lockfiles cause CI failures |
 | CI workflow | Automated testing prevents regressions |
+| Test script | Ensures `npm test` works |
+| Node engines | Specifies supported Node versions |
+| Outdated deps | Flags packages needing updates |
+| Security vulns | Catches high/critical vulnerabilities |
 
 ---
 

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -1,7 +1,9 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 
 const CHECKS = [
+  // File existence checks
   {
     name: 'package.json exists',
     check: async () => fileExists('package.json'),
@@ -28,7 +30,7 @@ const CHECKS = [
     fix: 'Add .gitignore. Try: npx gitignore node',
   },
   {
-    name: 'No package-lock.json AND pnpm-lock.yaml (pick one)',
+    name: 'No lockfile conflicts',
     check: async () => {
       const hasNpm = await fileExists('package-lock.json');
       const hasPnpm = await fileExists('pnpm-lock.yaml');
@@ -41,6 +43,62 @@ const CHECKS = [
     check: async () => fileExists('.github/workflows/ci.yml') || fileExists('.github/workflows/ci.yaml'),
     fix: 'Add .github/workflows/ci.yml for automated testing',
   },
+  // Package.json quality checks
+  {
+    name: 'Test script defined',
+    check: async () => {
+      const pkg = await readPackageJson();
+      return pkg?.scripts?.test && !pkg.scripts.test.includes('no test specified');
+    },
+    fix: 'Add a "test" script to package.json',
+  },
+  {
+    name: 'Node engines specified',
+    check: async () => {
+      const pkg = await readPackageJson();
+      return !!pkg?.engines?.node;
+    },
+    fix: 'Add "engines": { "node": ">=18.0.0" } to package.json',
+  },
+  // Dependency checks
+  {
+    name: 'No outdated dependencies',
+    check: async () => {
+      if (!await fileExists('package.json')) return true;
+      try {
+        execSync('npm outdated --json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+        return true; // No output means no outdated deps
+      } catch (err) {
+        // npm outdated exits with code 1 if there are outdated deps
+        const output = err.stdout?.toString() || '{}';
+        const outdated = JSON.parse(output);
+        return Object.keys(outdated).length === 0;
+      }
+    },
+    fix: 'Run: npm update (or npm outdated to see details)',
+  },
+  {
+    name: 'No security vulnerabilities',
+    check: async () => {
+      if (!await fileExists('package.json')) return true;
+      if (!await fileExists('package-lock.json') && !await fileExists('node_modules')) return true;
+      try {
+        execSync('npm audit --json', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+        return true;
+      } catch (err) {
+        const output = err.stdout?.toString() || '{}';
+        try {
+          const audit = JSON.parse(output);
+          const vulns = audit.metadata?.vulnerabilities || {};
+          const total = (vulns.high || 0) + (vulns.critical || 0);
+          return total === 0; // Pass if no high/critical vulns
+        } catch {
+          return true; // Can't parse, assume ok
+        }
+      }
+    },
+    fix: 'Run: npm audit fix (or npm audit for details)',
+  },
 ];
 
 async function fileExists(filepath) {
@@ -49,6 +107,15 @@ async function fileExists(filepath) {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function readPackageJson() {
+  try {
+    const content = await fs.readFile(path.resolve(process.cwd(), 'package.json'), 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds 4 new checks to increase the value delivered per run.

## New Checks

| Check | What It Does |
|-------|-------------|
| Test script defined | Validates `npm test` exists and isn't placeholder |
| Node engines specified | Ensures Node version requirements documented |
| No outdated dependencies | Runs `npm outdated` and flags stale packages |
| No security vulnerabilities | Runs `npm audit` and fails on high/critical |

## Changes

- `src/commands/check.js` - Added 4 new checks with shell integration
- `README.md` - Updated checks table
- `CHANGELOG.md` - Added entries

## Testing

```bash
npm test  # All 7 tests pass
node src/index.js check  # Now shows 11 checks
```

## Checklist

- [x] Tests pass
- [x] README updated
- [x] CHANGELOG updated

## Closes

- Closes #5

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Checks count | 7 | 11 |
| Actionable insights | File existence only | + deps + security |
